### PR TITLE
Use prebuilt binaries for js_of_ocaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "yojson": "https://github.com/npm-opam/yojson",
     "ocamlfind": "https://github.com/npm-opam/ocamlfind",
     "jenga-bin": "https://github.com/reasonml/jenga-bin",
-    "js_of_ocaml": "https://github.com/npm-opam/js_of_ocaml"
+    "js_of_ocaml-bin": "https://github.com/reasonml/js_of_ocaml-bin.git"
   },
   "description": "Prototype that conforms to the magic-build spec. Implemented with Jenga.",
   "devDependencies": {},


### PR DESCRIPTION
With a prebuilt binary, installing the entire rebel only takes 4 minutes now. 
