### PR TITLE
Update install command from `--save-dev` to `--save`

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Build system that conforms to the ideal [Reason](https://github.com/facebook/rea
 
 ## For Consumers
 
-- `npm install --save-dev reasonml/rebel`
+- `npm install --save reasonml/rebel`
 - Write some files in your `src/`, or install some spec compliant (see above) npm packages.
 - `./node_modules/.bin/rebel`. :tada: :tada:!
 - Binary in `_build/src/app.out`


### PR DESCRIPTION
Based on feedback from @vramana installing rebel as a dev dependency is not supported. This readme includes instructions to install as a dev dependency. I've updated the readme to reflect @vramana 's guidance.

change consumer install command to `--save` instead of `--save-dev`.
