### PR TITLE
Refactor parsing rebel config from package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,7 @@ Checkout this [example project](https://github.com/reasonml/RebelExampleProject)
 
 ## Rebel Config
 
-- backend (string): One of "jsoo", "native", "bucklescript".
-- targets ([string]): entry points for reason application. Currently only works with bucklescript.
+- targets ([ { target: string, engine: string, entry: string } ]): entry points for reason application. Multiple entry points currently only works with bucklescript. If no value is provided, the default value is `[{ target: "default", engine: "native", entry: "src/Index.re" }]`.
 - ocamlfindDependencies (array) : list of ocaml packages that work with ocamlfind
 
 ### More Info

--- a/examples/bs-project/package.json
+++ b/examples/bs-project/package.json
@@ -10,10 +10,17 @@
   "author": "",
   "license": "ISC",
   "rebel": {
-    "backend": "bucklescript",
     "targets": [
-      "client",
-      "server"
+      {
+        "target": "client",
+        "engine": "bucklescript",
+        "entry": "src/client.re"
+      },
+      {
+        "target": "server",
+        "engine": "bucklescript",
+        "entry": "src/server.re"
+      }
     ]
   },
   "dependencies": {

--- a/examples/reason-project/package.json
+++ b/examples/reason-project/package.json
@@ -14,7 +14,6 @@
     "remath": "https://github.com/vramana/remath.git"
   },
   "rebel": {
-    "backend": "native",
     "ocamlfindDependencies": [
       "core"
     ]

--- a/examples/recursive-src/package.json
+++ b/examples/recursive-src/package.json
@@ -14,6 +14,5 @@
     "remath": "github:vramana/remath"
   },
   "rebel": {
-    "backend": "native"
   }
 }

--- a/src/bucklescript.re
+++ b/src/bucklescript.re
@@ -19,7 +19,12 @@ let module Scheme = Jenga_lib.Api.Scheme;
 open Utils;
 
 let jsOutput =
-  (targets == [] ? ["index"] : targets) |>
+  (
+    rebelConfig.targets == [] ?
+      ["index"] :
+      List.map
+        f::(fun t => t.entry |> rel dir::Path.the_root |> fileNameNoExtNoDir) rebelConfig.targets
+  ) |>
   List.map f::(fun t => rel dir::(rel dir::buildDirRoot (tsl topLibName)) (t ^ ".js"));
 
 /* the module alias file takes the current library foo's first-party sources, e.g. A.re, B.re, and turn them

--- a/src/merlin.re
+++ b/src/merlin.re
@@ -138,7 +138,7 @@ let scheme dir::dir =>
   if (dir == Path.the_root) {
     let toplevelScheme =
       dotMerlinScheme
-        isTopLevelLib::true dir::dir libName::topLibName bscBackend::(backend == "bucklescript");
+        isTopLevelLib::true dir::dir libName::topLibName bscBackend::(rebelConfig.backend == "bucklescript");
     Scheme.all [
       Scheme.rules [Rule.default dir::dir [relD dir::Path.the_root ".merlin"]],
       toplevelScheme
@@ -148,7 +148,7 @@ let scheme dir::dir =>
   ) {
     let libName = Lib (Path.basename dir);
     dotMerlinScheme
-      isTopLevelLib::false dir::dir libName::libName bscBackend::(backend == "bucklescript")
+      isTopLevelLib::false dir::dir libName::libName bscBackend::(rebelConfig.backend == "bucklescript")
   } else {
     Scheme.no_rules
   };

--- a/src/native.re
+++ b/src/native.re
@@ -391,6 +391,7 @@ let finalOutputsScheme buildDir::buildDir libName::libName sortedSourcePaths::so
       (transitiveCmaPaths |> List.map f::tsp |> String.concat sep::" ")
       (tsp moduleAliasCmoPath)
       cmosString;
+  let backend = rebelConfig.backend;
   let nativeRule =
     /* We check here for jsoo because jsoo needs binaryOutput */
     backend == "native" || backend == "jsoo" ?
@@ -458,7 +459,7 @@ let compileLibScheme
 let scheme dir::dir =>
   if (dir == Path.the_root) {
     let defaultRule =
-      switch backend {
+      switch rebelConfig.backend {
       | "jsoo" => [Dep.path jsOutput]
       | "native" => [Dep.path binaryOutput]
       | _ => []

--- a/src/ocamlDep.re
+++ b/src/ocamlDep.re
@@ -18,8 +18,8 @@ open Utils;
    tracking in the presence of `open` */
 let ocamlDep sourcePath::sourcePath => {
   let flag = isInterface sourcePath ? "-intf" : "-impl";
-  let ppx = backend == "bucklescript" ? "-ppx bsppx.exe" : "";
-  let berror = backend == "bucklescript" ? "" : "| berror";
+  let ppx = rebelConfig.backend == "bucklescript" ? "-ppx bsppx.exe" : "";
+  let berror = rebelConfig.backend == "bucklescript" ? "" : "| berror";
   /* seems like refmt intelligently detects source code type (re/ml) */
   let getDepAction () =>
     bashf

--- a/src/setup.re
+++ b/src/setup.re
@@ -8,7 +8,9 @@ open Jenga_lib.Api;
 
 open Utils;
 
-let scheme dir::dir =>
+let scheme dir::dir => {
+  ignore dir;
+  let backend = rebelConfig.backend;
   switch backend {
   | "bucklescript" => Scheme.all [Bucklescript.scheme dir::dir, Merlin.scheme dir::dir]
   | "jsoo"
@@ -16,7 +18,8 @@ let scheme dir::dir =>
   | _ =>
     print_endline "Invalid backend it should be one of [ native, jsoo, bucklescript ]";
     Scheme.no_rules
-  };
+  }
+};
 
 let env () => Env.create
   /* TODO: this doesn't traverse down to _build so I can't ask it to clean files there? */


### PR DESCRIPTION
This removes `rebel.backend` and introduces `rebel.targets` as the sole way to control dependencies.
