### PR TITLE
Change default build dir from _build/ to _build/default

### DIFF
--- a/examples/bs-project/.merlin
+++ b/examples/bs-project/.merlin
@@ -18,7 +18,7 @@ S ./node_modules/Rexpress/src
 S ./node_modules/remath/src
 
 # B stands for build (artifacts). We generate ours into _build
-B ./_build/*
+B ./_build/default/*
 
 # Bucklescript build artifacts
 B ./node_modules/bs-platform/lib/ocaml
@@ -27,7 +27,7 @@ B ./node_modules/bs-platform/lib/ocaml
 # the location of third-party dependencies. For us, most of our third-party deps
 # reside in `node_modules/` (made visible to Merlin through the S command
 # above); this PKG command is for discovering the opam/ocamlfind packages.
-PKG 
+
 
 # FLG is the set of flags to pass to Merlin, as if it used ocamlc to compile and
 # understand our sources. You don't have to understand what these flags are for

--- a/examples/reason-project/.merlin
+++ b/examples/reason-project/.merlin
@@ -17,7 +17,7 @@ S src
 S ./node_modules/remath/src
 
 # B stands for build (artifacts). We generate ours into _build
-B ./_build/*
+B ./_build/default/*
 
 
 

--- a/examples/recursive-src/.merlin
+++ b/examples/recursive-src/.merlin
@@ -18,7 +18,7 @@ S ./node_modules/re-kebab/src
 S ./node_modules/remath/src
 
 # B stands for build (artifacts). We generate ours into _build
-B ./_build/*
+B ./_build/default/*
 
 
 
@@ -26,7 +26,7 @@ B ./_build/*
 # the location of third-party dependencies. For us, most of our third-party deps
 # reside in `node_modules/` (made visible to Merlin through the S command
 # above); this PKG command is for discovering the opam/ocamlfind packages.
-PKG 
+
 
 # FLG is the set of flags to pass to Merlin, as if it used ocamlc to compile and
 # understand our sources. You don't have to understand what these flags are for

--- a/src/bucklescript.re
+++ b/src/bucklescript.re
@@ -176,7 +176,7 @@ let compileSourcesScheme
 
         /** flag to include all the dependencies build dir's **/
         let includeDir =
-          thirdPartyNpmLibs |> List.map f::(fun libName => "-I _build/" ^ tsl libName) |>
+          thirdPartyNpmLibs |> List.map f::(fun libName => "-I " ^ tsp (rel dir::buildDirRoot (tsl libName))) |>
           String.concat sep::" ";
 
         /** Debug Info */

--- a/src/ocamlDep.re
+++ b/src/ocamlDep.re
@@ -12,7 +12,6 @@ let module Action = Jenga_lib.Api.Action;
 
 open Utils;
 
-
 /* Wrapper for the CLI `ocamldep`. Take the output, process it a bit, and pretend we've just called a regular
    ocamldep OCaml function. Note: the `ocamldep` utility doesn't give us enough info for fine, accurate module
    tracking in the presence of `open` */

--- a/src/utils.re
+++ b/src/utils.re
@@ -66,7 +66,7 @@ let hasInterface sourcePaths::sourcePaths path =>
 
 let nodeModulesRoot = rel dir::Path.the_root "node_modules";
 
-let buildDirRoot = rel dir::Path.the_root "_build";
+let buildDirRoot = rel dir::(rel dir::Path.the_root "_build") "default";
 
 let topSrcDir = rel dir::Path.the_root "src";
 
@@ -111,11 +111,11 @@ let getSourceFiles dir::dir => {
 /** Build Path Helpers **/
 let extractPackageName dir::dir => {
   let pathComponents = String.split on::'/' (tsp dir);
-  List.nth_exn pathComponents 1
+  List.nth_exn pathComponents 2
 };
 
 let convertBuildDirToLibDir buildDir::buildDir => {
-  let path = String.chop_prefix_exn (tsp buildDir) "_build/";
+  let path = String.chop_prefix_exn (tsp buildDir) ((tsp buildDirRoot) ^ "/");
   let pathComponents = String.split path on::'/';
 
   /** prepare base src path */
@@ -132,24 +132,6 @@ let convertBuildDirToLibDir buildDir::buildDir => {
     rel dir::basePath
   }
 };
-
-let convertLibDirToBuildDir libDir::libDir => {
-  let path = tsp libDir;
-  let pathComponents = String.split path on::'/';
-  if (List.nth_exn pathComponents 0 == "src") {
-    rel dir::buildDirRoot path
-  } else {
-    let packageName = extractPackageName dir::libDir;
-    let basePath = rel dir::buildDirRoot packageName;
-    if (List.length pathComponents == 3) {
-      basePath
-    } else {
-      List.slice pathComponents 3 (List.length pathComponents) |> String.concat sep::"/" |>
-      rel dir::basePath
-    }
-  }
-};
-
 
 /** Rebel-specific helpers **/
 type moduleName =


### PR DESCRIPTION
**Motivation**:

For multiple entry points, we use `_build/target-name` as the root directory for all the artifacts of the entry point. This change makes it easier to deal with that. Once the multiple entry point is finished, we can look into using `_build` as root directory for all artifacts when there is only one entry point. 

Also sneaked in a minor merlin change where if package.json doesn't declare and ocamlfind dependencies.
