### PR TITLE
Fix ocamlopt not trigger linking step in some cases

### DIFF
--- a/examples/recursive-src/package.json
+++ b/examples/recursive-src/package.json
@@ -20,7 +20,7 @@
         "engine": "native",
         "entry": "src/Index.re",
         "unstable_flags": {
-          "link": "-inline 100",
+          "link": "",
           "compile": "-verbose"
         }
       }

--- a/package.json
+++ b/package.json
@@ -22,10 +22,10 @@
   },
   "license": "ISC",
   "scripts": {
-    "rebel:me": "npm run rebel && ./rebel.sh examples/multiple-entrypoint",
-    "rebel:re": "npm run rebel && ./rebel.sh examples/reason-project",
-    "rebel:rs": "npm run rebel && ./rebel.sh examples/recursive-src",
-    "rebel:bs": "npm run rebel && ./rebel.sh examples/bs-project",
+    "rebel:me": "eval $(dependencyEnv) && npm run rebel && ./rebel.sh examples/multiple-entrypoint",
+    "rebel:re": "eval $(dependencyEnv) && npm run rebel && ./rebel.sh examples/reason-project",
+    "rebel:rs": "eval $(dependencyEnv) && npm run rebel && ./rebel.sh examples/recursive-src",
+    "rebel:bs": "eval $(dependencyEnv) && npm run rebel && ./rebel.sh examples/bs-project",
     "rebel": "eval $(dependencyEnv) && nopam && ./compile-rebel.sh",
     "editor": "eval $(dependencyEnv) && $EDITOR .",
     "postinstall": "npm run rebel"


### PR DESCRIPTION
When strings are changed inside print_endline the only the .o artifact seems to changes. It was not accounted it in the build graph. So the build is not being triggered.

Fixes #82 
