### PR TITLE
Use ocamlfind to invoke ocamldep and allow passing extra flags

### DIFF
--- a/src/ocamlDep.re
+++ b/src/ocamlDep.re
@@ -18,15 +18,17 @@ open Utils;
 let ocamlDep source::source target::target => {
   let flag = isInterface source ? "-intf" : "-impl";
   let ppx = target.engine == "bucklescript" ? "-ppx bsppx.exe" : "";
+  let extraFlags = target.flags.dep;
   /* betterError doesn't support bucklescript yet */
   let berror = target.engine == "bucklescript" ? "" : "| berror";
 
   /** seems like refmt intelligently detects source code type (re/ml) */
   let getDepAction () =>
     bashf
-      "ocamldep -pp refmt %s -ml-synonym .re -mli-synonym .rei -modules -one-line %s %s 2>&1 %s; (exit ${PIPESTATUS[0]})"
+      "ocamlfind ocamldep -pp refmt %s -ml-synonym .re -mli-synonym .rei -modules -one-line %s %s %s 2>&1 %s; (exit ${PIPESTATUS[0]})"
       ppx
       flag
+      extraFlags
       (tsp source)
       berror;
   let action = Dep.action_stdout (Dep.path source |> mapD getDepAction);

--- a/src/utils.re
+++ b/src/utils.re
@@ -215,7 +215,7 @@ let topologicalSort graph => {
 };
 
 /* package.json helpers */
-type flags = {compile: string, link: string, jsoo: string};
+type flags = {dep: string, compile: string, link: string, jsoo: string};
 
 type target = {
   target: string,
@@ -238,6 +238,11 @@ let parseTarget t => {
     switch flags {
     | Some f => f
     | None => `Assoc []
+    };
+  let dep =
+    switch (flags |> Util.to_option (fun a => a |> Util.member "dep")) {
+    | Some (`String _ as a) => Util.to_string a
+    | _ => ""
     };
   let compile =
     switch (flags |> Util.to_option (fun a => a |> Util.member "compile")) {
@@ -262,7 +267,7 @@ let parseTarget t => {
     | "byte" => ("ocamlc", ".cmo", ".cma")
     | _ => ("", "", "")
     };
-  {target, engine, entry, compiler, cmox, cmax, flags: {compile, link, jsoo}}
+  {target, engine, entry, compiler, cmox, cmax, flags: {dep, compile, link, jsoo}}
 };
 
 let defaultTarget = {
@@ -272,7 +277,7 @@ let defaultTarget = {
   compiler: "ocamlopt",
   cmox: ".cmx",
   cmax: ".cmxa",
-  flags: {compile: "", link: "", jsoo: ""}
+  flags: {dep: "", compile: "", link: "", jsoo: ""}
 };
 
 let rebelConfig = {


### PR DESCRIPTION
@jordwalke mentioned that we should be able to also pass extra flags to `ocamldep`, which would allow the user to do things like add ppx from libraries and such. I no longer have the need for this, but since he expressed interest in having it I went ahead and made a PR.

I also use `ocamlfind` to invoke `ocamldep` so that you can pass `-package` to it and it will automatically load ppx from the right libs (I think).

I don't know if this is the right thing to do, but it was nice to figure out how to get rebel running locally.