### PR TITLE
Add ignore_stderr to bashf.

### DIFF
--- a/src/ocamlDep.re
+++ b/src/ocamlDep.re
@@ -20,12 +20,11 @@ let ocamlDep source::source target::target => {
   let ppx = target.engine == "bucklescript" ? "-ppx bsppx.exe" : "";
   let extraFlags = target.flags.dep;
   /* betterError doesn't support bucklescript yet */
-  let berror = target.engine == "bucklescript" ? "" : "| berror";
+  let berror = target.engine == "bucklescript" ? "" : "2>&1 | berror";
 
   /** seems like refmt intelligently detects source code type (re/ml) */
   let getDepAction () =>
     bashf
-      ignore_stderr::true
       "ocamlfind ocamldep -pp refmt %s -ml-synonym .re -mli-synonym .rei -modules -one-line %s %s %s %s; (exit ${PIPESTATUS[0]})"
       ppx
       flag

--- a/src/ocamlDep.re
+++ b/src/ocamlDep.re
@@ -25,7 +25,8 @@ let ocamlDep source::source target::target => {
   /** seems like refmt intelligently detects source code type (re/ml) */
   let getDepAction () =>
     bashf
-      "ocamlfind ocamldep -pp refmt %s -ml-synonym .re -mli-synonym .rei -modules -one-line %s %s %s 2>&1 %s; (exit ${PIPESTATUS[0]})"
+      ignore_stderr::true
+      "ocamlfind ocamldep -pp refmt %s -ml-synonym .re -mli-synonym .rei -modules -one-line %s %s %s %s; (exit ${PIPESTATUS[0]})"
       ppx
       flag
       extraFlags

--- a/src/utils.re
+++ b/src/utils.re
@@ -43,9 +43,9 @@ let os_name = {
 
 
 /** jenga helpers */
-let bash ignore_stderr::ignore_stderr command => Action.process dir::Path.the_root prog::"bash" args::["-c", command] ignore_stderr::ignore_stderr ();
+let bash command => Action.process dir::Path.the_root prog::"bash" args::["-c", command] ();
 
-let bashf ignore_stderr::ignore_stderr=false fmt => ksprintf (bash ignore_stderr::ignore_stderr) fmt;
+let bashf fmt => ksprintf bash fmt;
 
 let relD dir::dir str => Dep.path (Path.relative dir::dir str);
 

--- a/src/utils.re
+++ b/src/utils.re
@@ -43,9 +43,9 @@ let os_name = {
 
 
 /** jenga helpers */
-let bash command => Action.process dir::Path.the_root prog::"bash" args::["-c", command] ();
+let bash ignore_stderr::ignore_stderr command => Action.process dir::Path.the_root prog::"bash" args::["-c", command] ignore_stderr::ignore_stderr ();
 
-let bashf fmt => ksprintf bash fmt;
+let bashf ignore_stderr::ignore_stderr=false fmt => ksprintf (bash ignore_stderr::ignore_stderr) fmt;
 
 let relD dir::dir str => Dep.path (Path.relative dir::dir str);
 


### PR DESCRIPTION
Seems like bucklescript outputs warnings when ocamldep is ran. Probably
through `bsppx.exe`. We just ignore stderr for ocamldep. Quick fix but
not necessarily right.

The warnings add text to the parsed output which makes rebel think ocamldep returns something wrong. Now it'll ignore stderr to get the right things out of ocamldep. The warnings will still appear later in the build process.