### PR TITLE
Add env vars

### DIFF
--- a/src/bucklescript.re
+++ b/src/bucklescript.re
@@ -175,15 +175,16 @@ let compileSourcesScheme
       bashf
         (
           if isInterface' {
-            "bsc.exe -g %s %s -pp refmt -bs-package-name self -bs-package-output commonjs:%s %s %s -o %s -c -intf %s 2>&1; (exit ${PIPESTATUS[0]})"
+            "%s bsc.exe -g %s %s -pp refmt -bs-package-name self -bs-package-output commonjs:%s %s %s -o %s -c -intf %s 2>&1; (exit ${PIPESTATUS[0]})"
           } else if (
             hasInterface' && String.is_suffix (Path.basename path) suffix::".re"
           ) {
-            "bsc.exe -g %s %s -pp refmt -bin-annot -bs-package-name self -bs-package-output commonjs:%s %s %s -o %s -c -intf-suffix .rei -impl %s 2>&1; (exit ${PIPESTATUS[0]})"
+            "%s bsc.exe -g %s %s -pp refmt -bin-annot -bs-package-name self -bs-package-output commonjs:%s %s %s -o %s -c -intf-suffix .rei -impl %s 2>&1; (exit ${PIPESTATUS[0]})"
           } else {
-            "bsc.exe -g %s %s -pp refmt -bin-annot -bs-package-name self -bs-package-output commonjs:%s %s %s -o %s -c -impl %s 2>&1; (exit ${PIPESTATUS[0]})"
+            "%s bsc.exe -g %s %s -pp refmt -bin-annot -bs-package-name self -bs-package-output commonjs:%s %s %s -o %s -c -impl %s 2>&1; (exit ${PIPESTATUS[0]})"
           }
         )
+        target.flags.envvars
         target.flags.compile
         ocamlfindPackagesStr
         (tsp buildDir)

--- a/src/ocaml.re
+++ b/src/ocaml.re
@@ -156,6 +156,7 @@ let compileSourcesScheme
       };
 
     let extraFlags = target.flags.compile;
+    let envvars = target.flags.envvars;
 
     /** Debug Info */
     /* print_endline ("Path: " ^ tsp path);
@@ -179,15 +180,16 @@ let compileSourcesScheme
       bashf
         (
           if isInterface' {
-            "ocamlfind %s -pp refmt -g -w -30 -w -40 %s -I %s %s %s %s -o %s -c -intf %s 2>&1| berror; (exit ${PIPESTATUS[0]})"
+            "%s ocamlfind %s -pp refmt -g -w -30 -w -40 %s -I %s %s %s %s -o %s -c -intf %s 2>&1| berror; (exit ${PIPESTATUS[0]})"
           } else if (
             hasInterface' && String.is_suffix (Path.basename path) suffix::".re"
           ) {
-            "ocamlfind %s -pp refmt -bin-annot -g -w -30 -w -40 %s -I %s %s %s %s -o %s -c -intf-suffix .rei -impl %s 2>&1| berror; (exit ${PIPESTATUS[0]})"
+            "%s ocamlfind %s -pp refmt -bin-annot -g -w -30 -w -40 %s -I %s %s %s %s -o %s -c -intf-suffix .rei -impl %s 2>&1| berror; (exit ${PIPESTATUS[0]})"
           } else {
-            "ocamlfind %s -pp refmt -bin-annot -g -w -30 -w -40 %s -I %s %s %s %s -o %s -c -impl %s 2>&1| berror; (exit ${PIPESTATUS[0]})"
+            "%s ocamlfind %s -pp refmt -bin-annot -g -w -30 -w -40 %s -I %s %s %s %s -o %s -c -impl %s 2>&1| berror; (exit ${PIPESTATUS[0]})"
           }
         )
+        envvars
         compiler
         ("-open " ^ moduleName)
         (tsp buildDir)

--- a/src/ocamlDep.re
+++ b/src/ocamlDep.re
@@ -21,12 +21,11 @@ let ocamlDep source::source target::target => {
   let extraFlags = target.flags.dep;
   let envvars = target.flags.envvars;
   /* betterError doesn't support bucklescript yet */
-  let berror = target.engine == "bucklescript" ? "" : "| berror";
+  let berror = target.engine == "bucklescript" ? "" : "2>&1| berror";
 
   /** seems like refmt intelligently detects source code type (re/ml) */
   let getDepAction () =>
     bashf
-      ignore_stderr::true
       "%s ocamlfind ocamldep -pp refmt %s %s -ml-synonym .re -mli-synonym .rei -modules -one-line %s %s %s; (exit ${PIPESTATUS[0]})"
       envvars
       ppx

--- a/src/ocamlDep.re
+++ b/src/ocamlDep.re
@@ -19,6 +19,7 @@ let ocamlDep source::source target::target => {
   let flag = isInterface source ? "-intf" : "-impl";
   let ppx = target.engine == "bucklescript" ? "-ppx bsppx.exe" : "";
   let extraFlags = target.flags.dep;
+  let envvars = target.flags.envvars;
   /* betterError doesn't support bucklescript yet */
   let berror = target.engine == "bucklescript" ? "" : "| berror";
 
@@ -26,10 +27,11 @@ let ocamlDep source::source target::target => {
   let getDepAction () =>
     bashf
       ignore_stderr::true
-      "ocamlfind ocamldep -pp refmt %s -ml-synonym .re -mli-synonym .rei -modules -one-line %s %s %s %s; (exit ${PIPESTATUS[0]})"
+      "%s ocamlfind ocamldep -pp refmt %s %s -ml-synonym .re -mli-synonym .rei -modules -one-line %s %s %s; (exit ${PIPESTATUS[0]})"
+      envvars
       ppx
-      flag
       extraFlags
+      flag
       (tsp source)
       berror;
   let action = Dep.action_stdout (Dep.path source |> mapD getDepAction);

--- a/src/ocamlDep.re
+++ b/src/ocamlDep.re
@@ -25,7 +25,8 @@ let ocamlDep source::source target::target => {
   /** seems like refmt intelligently detects source code type (re/ml) */
   let getDepAction () =>
     bashf
-      "ocamlfind ocamldep -pp refmt %s -ml-synonym .re -mli-synonym .rei -modules -one-line %s %s %s 2>&1 %s; (exit ${PIPESTATUS[0]})"
+      ignore_stderr::true
+      "ocamlfind ocamldep -pp refmt %s -ml-synonym .re -mli-synonym .rei -modules -one-line %s %s %s %s; (exit ${PIPESTATUS[0]})"
       ppx
       flag
       extraFlags

--- a/src/utils.re
+++ b/src/utils.re
@@ -43,9 +43,9 @@ let os_name = {
 
 
 /** jenga helpers */
-let bash ignore_stderr::ignore_stderr command => Action.process dir::Path.the_root prog::"bash" args::["-c", command] ignore_stderr::ignore_stderr ();
+let bash command => Action.process dir::Path.the_root prog::"bash" args::["-c", command] ();
 
-let bashf ignore_stderr::ignore_stderr=false fmt => ksprintf (bash ignore_stderr::ignore_stderr) fmt;
+let bashf fmt => ksprintf bash fmt;
 
 let relD dir::dir str => Dep.path (Path.relative dir::dir str);
 

--- a/src/utils.re
+++ b/src/utils.re
@@ -43,9 +43,9 @@ let os_name = {
 
 
 /** jenga helpers */
-let bash command => Action.process dir::Path.the_root prog::"bash" args::["-c", command] ();
+let bash ignore_stderr::ignore_stderr command => Action.process dir::Path.the_root prog::"bash" args::["-c", command] ignore_stderr::ignore_stderr ();
 
-let bashf fmt => ksprintf bash fmt;
+let bashf ignore_stderr::ignore_stderr=false fmt => ksprintf (bash ignore_stderr::ignore_stderr) fmt;
 
 let relD dir::dir str => Dep.path (Path.relative dir::dir str);
 

--- a/src/utils.re
+++ b/src/utils.re
@@ -215,7 +215,7 @@ let topologicalSort graph => {
 };
 
 /* package.json helpers */
-type flags = {dep: string, compile: string, link: string, jsoo: string};
+type flags = {dep: string, compile: string, link: string, jsoo: string, envvars: string};
 
 type target = {
   target: string,
@@ -259,6 +259,11 @@ let parseTarget t => {
     | Some (`String f) => f
     | _ => ""
     };
+  let envvars =
+    switch (flags |> Util.to_option (fun a => a |> Util.member "envvars")) {
+    | Some (`String f) => f
+    | _ => ""
+    };
   let (compiler, cmox, cmax) =
     switch engine {
     | "native" => ("ocamlopt", ".cmx", ".cmxa")
@@ -267,7 +272,7 @@ let parseTarget t => {
     | "byte" => ("ocamlc", ".cmo", ".cma")
     | _ => ("", "", "")
     };
-  {target, engine, entry, compiler, cmox, cmax, flags: {dep, compile, link, jsoo}}
+  {target, engine, entry, compiler, cmox, cmax, flags: {dep, compile, link, jsoo, envvars}}
 };
 
 let defaultTarget = {
@@ -277,7 +282,7 @@ let defaultTarget = {
   compiler: "ocamlopt",
   cmox: ".cmx",
   cmax: ".cmxa",
-  flags: {dep: "", compile: "", link: "", jsoo: ""}
+  flags: {dep: "", compile: "", link: "", jsoo: "", envvars: ""}
 };
 
 let rebelConfig = {


### PR DESCRIPTION
This PR adds a new flag `envvars` which allows you to add environment variables specific to a target.
This is used in [reglexampleproject](https://github.com/bsansouci/reglexampleproject) to pass an env var to [matchenv](https://github.com/bsansouci/matchenv).